### PR TITLE
edits and restructures copy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,8 +88,8 @@ rssLimit = 25
   # Author Settings
   [params.author]
     author__name = "DevRel Diaries"
-    author__title = "<span class='text-span'>Hello</span> We are DevRel Diaries"
-    author__bio = "We are collecting and sharing real-life stories from real-life Developer Relations Professionals. Please feel free to share with us! See [how to contribute](/about/)."
+    author__title = "<span class='text-span'>Hello,</span> We are DevRel Diaries"
+    author__bio = "We are collecting and sharing real-life stories about mental health from real-life Developer Relations Professionals. Please, share your story with us! See [how you can contribute](/about/)."
     author__image = "/images/bethany-randall-XgZ0et0FUS8-unsplash.jpg"
     author__avatar = "/images/DevAdv.png"
     button__text = "See our stories"

--- a/content/about.md
+++ b/content/about.md
@@ -8,7 +8,7 @@ date: 2021-07-15
 
 ## <span class='text-span'>Who</span> are we?
 
-We are DevRel Professionals just like you. We are passionate about Developer Relations as well as the health and happiness of others. We want to make discussing mental health and wellness ok within DevRel communities so we've started this experiment to do just that.
+We are DevRel Professionals just like you. We are passionate about Developer Relations as well as the health and happiness of others. We want to normalise discussing mental health and wellness within DevRel communities so we've started this experiment to do just that.
 
 We're not entirely certain where this will lead, but as a first step we wanted to provide a platform where DevRel professionals can share their stories about Mental Health in DevRel. We hope that this will help others feel more comfortable sharing their own stories and experiences.
 
@@ -16,33 +16,9 @@ This project is carefully and lovingly created and curated by
 - Rain Leander [![web](/images/www.png)](https://therain.dev) [![twitter](/images/twit-32.png)](https://twitter.com/rainleander)
 - David G. Simmons [![web](/images/www.png)](https://davidgs.com) [![twitter](/images/twit-32.png)](https://twitter.com/davidgsIoT)
 
-## <span class='text-span'>What</span> is 'your story'?
-
-Your story, really, is whatever you want it to be. Whatever you've experienced. This site is about *your* lived experience with mental health in DevRel. Some basic ideas:
-
-- Have you experienced a mental health crisis? We'd love to hear about what happened, and how you dealt with it.
-- Have you experienced a mental health crisis and *not* dealt with it? We'd love to hear about that too.
-- Have you experienced a mental health crisis and dealt with it in a way that you think others could benefit from? We'd love to hear the story around that.
-- Have you experienced discrimination, or worked in a low-trust environment because of your mental health issues? Tell us about that, how it affected you, and how you dealt with it.
-
-Really, we are interested in hearing your stories about *any* aspect of mental health, mental wellness, self-care and self-awareness, and how it relates to DevRel. We want to help alleviate the stigma of mental health issues in tech. We hope to show others that it's ok to talk about it, and that they are not alone in their struggles.
-
-You never know the impact your story, your life experience, can have on someone. What to you was a trivial 'aha!' moment, could be a life-changing revelation for someone else.
-
-## <span class='text-span'>How</span> this works
-
-We want to let you share your story.
-
-We want you to feel safe sharing your story.
-
-The very **first** thing is to make sure you're aware of, and agree to, our [Code of Conduct](/code_of_conduct/) and [Privacy Policy](/privacy_policy/).
-
-Once you've done that, you can submit your story. We'll review it, and if it's appropriate, we'll publish it. We'll also share it on our social media channels. [@DevRelDiaries](https://twitter.com/DevRelDiaries) on Twitter.
-
 ### How to submit your story
 
-Really, we're trying to make this as easy as possible. Please see the [instructions for submitting your story](/contribute/).
-
+We're trying to make this as easy as possible. Please see the [instructions for submitting your story](/contribute/). You can submit your story anonymously as well, if that's what you prefer.
 
 ## <span class='text-span'>Words</span> of wisdom
 

--- a/content/contribute.md
+++ b/content/contribute.md
@@ -5,15 +5,26 @@ image_caption: "Photo by <a href=\"https://unsplash.com/@nate_dumlao?utm_source=
 description: "Contributing to DevRel Diaries"
 date: 2021-07-15
 ---
+
+## <span class='text-span'>What</span> we're looking for
+
+Your story is whatever you want it to be. Whatever you've experienced. This site is about *your* lived experience with mental health in Devrel. Some basic ideas:
+
+- Have you experienced a mental health crisis? We'd love to hear about what happened, and how you dealt with it.
+- Have you experienced a mental health crisis and *not* dealt with it? We'd love to hear about that too.
+- Have you experienced a mental health crisis and dealt with it in a way that you think others could benefit from? We'd love to hear the story around that.
+- Have you experienced discrimination, or worked in a low-trust environment because of your mental health issues? Tell us about that, how it affected you, and how you dealt with it.
+
+Really, we are interested in hearing your stories about *any* aspect of mental health, mental wellness, self-care and self-awareness, and how it relates to DevRel. We want to help alleviate the stigma of mental health issues in tech. We hope to show others that it's ok to talk about it, and that they are not alone in their struggles.
+
+You never know the impact your story, your life experience, can have on someone. What to you was a trivial 'aha!' moment, could be a life-changing revelation for someone else. 
 ## <span class='text-span'>How</span> this works
 
-We want to let you share your story. But we also recognize that sharing a personal story, especially about Mental Health, can be a difficult thing to do. So we've created a process that we hope will make it easier for you.
+We recognize that sharing a personal story, especially about mental health, can be a difficult thing to do. So we've created a process that we hope will make it easier for you by giving you the option to contribute either with your name or anonymously. We want you to feel safe sharing your story.
 
-We want you to feel safe sharing your story.
+Below are the instructions for the two _best_ ways to contribute your story. If neither of these work for you, please [reach out](mailto:stories@devreldiaries.com) to us and let's work together to find something that works.
 
-The very **first** thing though is to make sure you're aware of, and agree to, our [Code of Conduct](/code_of_conduct/) and our [Privacy Policy](/privacy_policy). We take these *very* seriously. You should too.
-
-We're making it as easy as we can for you to share your story in whatever way makes you the most confortable. Below are the instructions for the two _best_ ways to contribute your story. If neither of these work for you, please [reach out](mailto:stories@devreldiaries.com) to us and let's work together to find something that works.
+The very **first** thing is to make sure you're aware of, and agree to, our [Code of Conduct](/code_of_conduct/) and our [Privacy Policy](/privacy_policy). We take these *very* seriously. You should too.
 
 ## <span class='text-span'>Contributing</span> anonymously
 
@@ -44,7 +55,7 @@ Publishing your story will look something like this:
 
 ### <span class='text-span'>Submitting</span> your story
 
-Once you're done editing your story, you can submit it by clicking the `Submit` button at the bottom of the page. Before you are able to clik the `Submit` button you must confirm that you agree to the [Code of Conduct](/code_of_conduct/) and our [Privacy Policy](/privacy_policy). If you don't agree, you can't submit your story. If you do agree, you can click the `Submit` button and your story will be submitted for review. We will review your story and publish it as soon as we can. If we have any questions or concerns we will reach out to you (if possible) and work with you to resolve them. If we can't reach you, we may have to remove your story.
+Once you're done editing your story, you can submit it by clicking the `Submit` button at the bottom of the page. Before you are able to click the `Submit` button you must confirm that you agree to the [Code of Conduct](/code_of_conduct/) and our [Privacy Policy](/privacy_policy). If you don't agree, you can't submit your story. Once you click the `Submit` button, your story will be submitted for review. We will review your story and publish it as soon as we can. If we have any questions or concerns we will reach out to you (if possible) and work with you to resolve them. If we can't reach you, we may have to remove your story. We'll also share it on our social media channels. [@DevRelDiaries](https://twitter.com/DevRelDiaries) on Twitter.
 
 ## <span class='text-span'>Contributing</span> using GitHub
 


### PR DESCRIPTION
I edited the copy (just some basic cleanup, typo removal, clarifications) and restructured it a bit so that it feels more logical: The main info on how to contribute is now all on the “contribute” page, while the “about”page is now dedicated to the actual about information.

I would also suggest removing the “pages” dropdown from the nav because you already have the “stories” in the nav right next to it. Instead of “pages” just put the “about” page into the nav.

I think the contribution instructions are extremely detailed. It might be worth looking into shortening that a bit but it’s not absolutely necessary.

Right, hope I haven’t done anything wrong. This is basically my first PR ever 😆🙈